### PR TITLE
Add mesh integration plan and fix viewer build errors

### DIFF
--- a/docs/idea_tracking.md
+++ b/docs/idea_tracking.md
@@ -1,3 +1,52 @@
 # Idea Tracking
 
-This document will track brilliant or overreaching ideas that are worth considering for future development.
+This document tracks larger ideas that may become roadmap items.
+
+## Plan: Integrate research mesh results into the viewer
+
+Reference source for generated artifacts and scripts:
+- `greenhouse_org/scripts/research/mesh` in the external repository.
+
+### Goal
+Surface mesh-tooling outputs (nodes, relationships, clusters, and confidence/metadata) directly in `multiple_viewer` so users can inspect and navigate research-derived structures alongside the existing graph workflows.
+
+### Phase 1 — Discovery and contract definition
+1. Inventory mesh output files produced by the research scripts (JSON/CSV/schema/version fields).
+2. Define a stable import contract in this project:
+   - Required fields (id, label/title, links/edges).
+   - Optional fields (cluster/topic, confidence, source refs, timestamps).
+   - Versioning field to protect against schema drift.
+3. Add a short `docs/mesh_import_contract.md` with examples and failure behavior.
+
+### Phase 2 — Import pipeline in `multiple_viewer`
+1. Add a parser module (e.g., `src/import/mesh_importer.*`) that transforms mesh output into `GraphNode` + edge updates.
+2. Implement strict + permissive modes:
+   - Strict mode fails fast on invalid required fields.
+   - Permissive mode imports valid records and logs skipped rows.
+3. Add command-line support for loading mesh artifacts at startup (path + mode flags).
+
+### Phase 3 — Viewer UX integration
+1. Add visual cues for mesh metadata:
+   - Confidence bands (high/med/low styling).
+   - Cluster/group indicators.
+   - Optional source marker icon/text in node detail/page view.
+2. Add filter and search extensions:
+   - Filter by cluster.
+   - Filter by confidence threshold.
+   - Search in mesh-derived metadata fields.
+3. Ensure view modes (Perspective, Nexus Flow, Book) can render imported mesh data without layout regressions.
+
+### Phase 4 — Validation and quality gates
+1. Unit tests for parser behavior against valid/invalid fixture files.
+2. Integration tests for end-to-end import + render smoke path.
+3. Regression checks for existing CSV workflows to ensure mesh support is additive.
+
+### Phase 5 — Operationalization
+1. Add example mesh fixture(s) in `data/` and document usage in `docs/testing_guide.md`.
+2. Add logging metrics (import counts, skipped records, parse duration).
+3. Add a follow-up task for incremental refresh if mesh outputs are regenerated frequently.
+
+### Risks / open questions
+- Schema volatility in the external mesh scripts may require a version adapter layer.
+- Large mesh datasets may require lazy loading or pagination in book/page views.
+- Need decision on whether mesh confidence should influence physics/layout weights.

--- a/src/search_logic.cpp
+++ b/src/search_logic.cpp
@@ -22,8 +22,8 @@ std::vector<int> findSimilarTopics(const Graph& graph, const std::string& search
     if (tokens.empty()) return {};
 
     for (const auto& node : graph.nodes) {
-        std::string l = node.label;
-        for (auto &c : l) c = std::tolower((unsigned char)c);
+        std::string lowerLabel = node.label;
+        for (auto &c : lowerLabel) c = std::tolower((unsigned char)c);
 
         bool allTokensMatch = true;
         for (const auto& t : tokens) {

--- a/src/viewer_logic.cpp
+++ b/src/viewer_logic.cpp
@@ -486,7 +486,7 @@ void runEditor(Graph& graph, bool runTests) {
     initClearScreen();
     // drawViewerMenu(); // Removed direct menu draw, should be handled by status or overlay
 
-    // NexusPhysicsState nexusPhysics; // Decoupled
+    NexusPhysicsState nexusPhysics;
     ViewContext view;
     input::CommandStack commandStack;
     input::ShortcutManager shortcutManager;
@@ -578,6 +578,8 @@ void runEditor(Graph& graph, bool runTests) {
             layout::LayoutManager::applyPerspectiveBFS(graph, view);
         } else if (view.currentViewMode == VM_NEXUS_FLOW) {
             layout::LayoutManager::applyForceDirected(graph, view);
+        }
+
         switch (view.currentViewMode) {
             case VM_NEXUS_FLOW:
                 renderNexusFlow(graph, nexusPhysics, searchState);


### PR DESCRIPTION
### Motivation
- Provide a concrete plan to ingest and surface research mesh outputs from `greenhouse_org/scripts/research/mesh` inside the viewer so mesh-derived nodes/edges/metadata can be inspected alongside existing graph workflows.
- Resolve current compilation failures in the viewer/search code that prevented building the project.

### Description
- Expand `docs/idea_tracking.md` with a phased integration plan covering schema/contract, importer pipeline, UX integration, validation, and operationalization.
- Fix search logic by creating a lowercase label `lowerLabel` and using it for token matching in `findSimilarTopics` (`src/search_logic.cpp`).
- Restore `NexusPhysicsState nexusPhysics` initialization and close the layout-selection `if/else` block before the display-mode `switch` to fix brace/symbol errors in `runEditor` (`src/viewer_logic.cpp`).

### Testing
- Built the project using `cmake --build build -j4` which completed successfully and produced the `viewer`, `unit_tests`, and `bdd_tests` targets. 
- Ran test discovery with `ctest --test-dir build --output-on-failure` which completed and reported no tests were discovered in this configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02d62c26c83289cdee9cc66204d99)