### PR TITLE
Relocate test artifacts to tests/temp/ directory

### DIFF
--- a/tests/bdd/features/data_analytics.feature
+++ b/tests/bdd/features/data_analytics.feature
@@ -2,14 +2,14 @@ Feature: Data I/O and Analytics
   Scenarios covering enhancements 31-50.
 
   Scenario: Multi-format loading
-    Given a file "graph_data.json" in JSON format
-    When I load the graph from "graph_data.json"
+    Given a file "tests/temp/graph_data.json" in JSON format
+    When I load the graph from "tests/temp/graph_data.json"
     Then the graph should contain "50" nodes and "120" edges
 
   Scenario: SVG Export
     Given a populated graph
-    When I export the graph as SVG to "output.svg"
-    Then the file "output.svg" should be created and contain "<svg" tags
+    When I export the graph as SVG to "tests/temp/output.svg"
+    Then the file "tests/temp/output.svg" should be created and contain "<svg" tags
 
   Scenario: Community Detection
     Given a graph with three distinct clusters

--- a/tests/bdd/features/original_functionality.feature
+++ b/tests/bdd/features/original_functionality.feature
@@ -22,9 +22,9 @@ Feature: Original Viewer Functionality
 
   Scenario: Graph Persistence
     Given a persistent graph with nodes 1 and 2
-    When I save the graph to "bdd_persist_test.csv"
+    When I save the graph to "tests/temp/bdd_persist_test.csv"
     And I clear the current graph
-    And I load the graph from "bdd_persist_test.csv"
+    And I load the graph from "tests/temp/bdd_persist_test.csv"
     Then the graph should restore all previous nodes and edges
 
   Scenario: Graph Analytics

--- a/tests/sdd/cards/QuantaGliaClass.cpp
+++ b/tests/sdd/cards/QuantaGliaClass.cpp
@@ -11,7 +11,7 @@ using namespace Sorrel::Sdd::Util;
 // @Card: quanta_glia_extraction
 // @Results quanta_glia_extraction_operational == true
 void quanta_glia_extraction_card(const std::map<std::string, std::string>& facts) {
-    std::string test_file = "sdd_test_graph.json";
+    std::string test_file = "../../tests/temp/sdd_test_graph.json";
     Graph g;
     g.addNode(GraphNode("Extraction Test", 0));
 

--- a/tests/sdd/cpp/util/fact_utils.h
+++ b/tests/sdd/cpp/util/fact_utils.h
@@ -75,7 +75,7 @@ public:
             if (trimmed.empty() || trimmed[0] == '#' || trimmed.find("Situation:") == 0) continue;
 
             size_t space_pos = trimmed.find(' ');
-            if (space_pos == std::npos) continue;
+            if (space_pos == std::string::npos) continue;
 
             std::string rest = trim(trimmed.substr(space_pos + 1));
             size_t eq_pos = rest.find('=');

--- a/tests/unit/test_logic.cpp
+++ b/tests/unit/test_logic.cpp
@@ -84,10 +84,10 @@ void testGraphSerialization() {
     g.addNode(GraphNode("Node C", 2, {1}, 1, 1));
     g.addEdge(0, 1);
     g.addEdge(1, 2);
-    io::IOManager::saveGraphToCSV(g, "test_graph_tmp.csv");
+    io::IOManager::saveGraphToCSV(g, "tests/temp/test_graph_tmp.csv");
 
     Graph g2;
-    bool ok = io::IOManager::loadGraphFromCSV(g2, "test_graph_tmp.csv");
+    bool ok = io::IOManager::loadGraphFromCSV(g2, "tests/temp/test_graph_tmp.csv");
     TEST("CSV reload success", ok);
     TEST("CSV reload node count", g2.nodeMap.size() == 3);
     TEST("CSV reload edge count", g2.edgeCount() == 2);
@@ -99,10 +99,10 @@ void testGraphSerializationJSON() {
     g.addNode(GraphNode("Node A", 0));
     g.addNode(GraphNode("Node B", 1));
     g.addEdge(0, 1);
-    io::IOManager::saveJSON(g, "test_graph_tmp.json");
+    io::IOManager::saveJSON(g, "tests/temp/test_graph_tmp.json");
 
     Graph g2;
-    bool ok = io::IOManager::loadJSON(g2, "test_graph_tmp.json");
+    bool ok = io::IOManager::loadJSON(g2, "tests/temp/test_graph_tmp.json");
     TEST("JSON reload success", ok);
     TEST("JSON reload node count", g2.nodeMap.size() == 2);
     TEST("JSON reload edge count", g2.edgeCount() == 1);

--- a/tests/unit/testsuite2_logic.cpp
+++ b/tests/unit/testsuite2_logic.cpp
@@ -152,12 +152,12 @@ void testFileOperations(TestRunner& runner) {
     graph.addEdge(1, 2);
     
     // Test saving to CSV
-    bool saveSuccess = io::IOManager::saveGraphToCSV(graph, "test_output.csv");
+    bool saveSuccess = io::IOManager::saveGraphToCSV(graph, "tests/temp/test_output.csv");
     runner.runTest("Save Graph to CSV", saveSuccess, "Should successfully save graph to CSV");
     
     // Test loading from CSV
     Graph loadedGraph;
-    bool loadSuccess = io::IOManager::loadGraphFromCSV(loadedGraph, "test_output.csv");
+    bool loadSuccess = io::IOManager::loadGraphFromCSV(loadedGraph, "tests/temp/test_output.csv");
     runner.runTest("Load Graph from CSV", loadSuccess, "Should successfully load graph from CSV");
     
     if (loadSuccess) {
@@ -523,14 +523,14 @@ void testEdgeCases(TestRunner& runner) {
 
     // Test loading malformed CSV files
     Graph malformedGraph;
-    createTestFile("malformed.csv", "index,label,weight,neighbors\n1,A,10,[2\n");
-    runner.runTest("Load Malformed CSV (Bracket)", !io::IOManager::loadGraphFromCSV(malformedGraph, "malformed.csv"), "Should fail to load CSV with syntax error");
+    createTestFile("tests/temp/malformed.csv", "index,label,weight,neighbors\n1,A,10,[2\n");
+    runner.runTest("Load Malformed CSV (Bracket)", !io::IOManager::loadGraphFromCSV(malformedGraph, "tests/temp/malformed.csv"), "Should fail to load CSV with syntax error");
 
-    createTestFile("malformed.csv", "index,label,weight,neighbors\n1,A,ten,[2]\n");
-    runner.runTest("Load Malformed CSV (Value)", !io::IOManager::loadGraphFromCSV(malformedGraph, "malformed.csv"), "Should fail to load CSV with value error");
+    createTestFile("tests/temp/malformed.csv", "index,label,weight,neighbors\n1,A,ten,[2]\n");
+    runner.runTest("Load Malformed CSV (Value)", !io::IOManager::loadGraphFromCSV(malformedGraph, "tests/temp/malformed.csv"), "Should fail to load CSV with value error");
 
-    createTestFile("malformed.csv", "index,label,weight\n1,A,10\n");
-    runner.runTest("Load Malformed CSV (Column)", !io::IOManager::loadGraphFromCSV(malformedGraph, "malformed.csv"), "Should fail to load CSV with missing column");
+    createTestFile("tests/temp/malformed.csv", "index,label,weight\n1,A,10\n");
+    runner.runTest("Load Malformed CSV (Column)", !io::IOManager::loadGraphFromCSV(malformedGraph, "tests/temp/malformed.csv"), "Should fail to load CSV with missing column");
 
     // Test with extreme values
     Graph extremeGraph;
@@ -542,7 +542,7 @@ void testEdgeCases(TestRunner& runner) {
     runner.runTest("Add Node with Extreme Values", extremeGraph.nodeExists(2147483647), "Should handle max int index");
 
     // Clean up test file
-    remove("malformed.csv");
+    remove("tests/temp/malformed.csv");
 }
 
 // Main test runner

--- a/tests/unit/testsuite4_logic.cpp
+++ b/tests/unit/testsuite4_logic.cpp
@@ -77,15 +77,15 @@ void testHotReload() {
     repo.clearAll();
 
     // Create a temporary atlas file
-    std::ofstream tmp("tmp_atlas.csv");
+    std::ofstream tmp("tests/temp/tmp_atlas.csv");
     tmp << "REGION,R1,Region 1,0,0,0,10\n";
     tmp.close();
 
-    repo.loadAtlas("tmp_atlas.csv");
+    repo.loadAtlas("tests/temp/tmp_atlas.csv");
     TEST_PHASE1("Initial load", repo.getModel().getRegions().size() == 1);
 
     // Modify atlas file
-    std::ofstream tmp2("tmp_atlas.csv");
+    std::ofstream tmp2("tests/temp/tmp_atlas.csv");
     tmp2 << "REGION,R1,Region 1,0,0,0,10\n";
     tmp2 << "REGION,R2,Region 2,100,100,100,5\n";
     tmp2.close();
@@ -99,11 +99,11 @@ void testProbabilisticMembership() {
     auto& repo = ModelRepository::getInstance();
 
     // Create a temporary overlay file
-    std::ofstream tmp("tmp_overlay.csv");
+    std::ofstream tmp("tests/temp/tmp_overlay.csv");
     tmp << "MAP,1,R1,,0.85\n"; // probabilistic mapping
     tmp.close();
 
-    repo.loadOverlay("tmp_overlay.csv");
+    repo.loadOverlay("tests/temp/tmp_overlay.csv");
     const auto& mappings = repo.getOverlay().getAllMappings();
     bool found = false;
     for (const auto& [nodeId, m] : mappings) {


### PR DESCRIPTION
I have relocated all test-generated artifacts from the root directory to a newly created `tests/temp/` directory. This involved updating file paths in unit tests, BDD feature files, and SDD cards. I also fixed a minor compilation issue in a shared test utility and ensured the new directory is tracked by Git using a `.keep` file. Verified that all tests pass and the root directory remains clean.

---
*PR created automatically by Jules for task [11216920557054041275](https://jules.google.com/task/11216920557054041275) started by @drtamarojgreen*